### PR TITLE
Fix 'cannot create context from nil parent' panic

### DIFF
--- a/server.go
+++ b/server.go
@@ -197,7 +197,7 @@ func (s *Server) Upgrade(ctx *fasthttp.RequestCtx) {
 				ctx.Response.Header.AddBytesK(wsHeaderProtocol, proto)
 			}
 
-			var nctx context.Context
+			nctx := context.Background()
 			ctx.VisitUserValues(func(k []byte, v interface{}) {
 				nctx = context.WithValue(nctx, string(k), v)
 			})


### PR DESCRIPTION
An issue introduced with the v0.0.10 to support standard context.Context
for net/http does not use an initialized context, causing the `context`
package to panic with `cannot create context from nil parent`.

This commit changes `nctx` so that it is initialized with the
`context.Background()` value.