### PR TITLE
Fix: avoid panic by never closing channel twice

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -21,8 +21,11 @@ type Conn struct {
 
 	input  chan *Frame
 	output chan *Frame
-	closer chan struct{}
-	errch  chan error
+
+	closer    chan struct{}
+	closeOnce sync.Once
+
+	errch chan error
 
 	// buffered messages
 	buffered *bytebufferpool.ByteBuffer
@@ -242,7 +245,7 @@ func (c *Conn) CloseDetail(status StatusCode, reason string) {
 
 		c.WriteFrame(fr)
 
-		close(c.closer)
+		c.closeOnce.Do(func() { close(c.closer) })
 	}
 
 	return

--- a/server.go
+++ b/server.go
@@ -462,7 +462,7 @@ func (s *Server) handlePong(c *Conn, data []byte) {
 }
 
 func (s *Server) handleClose(c *Conn, fr *Frame) {
-	defer close(c.closer)
+	defer c.closeOnce.Do(func() { close(c.closer) })
 	c.errch <- func() error {
 		if fr.Status() != StatusNone {
 			return Error{


### PR DESCRIPTION
we need to never close that channel twice, that's an easy way to catch a stacktrace (as I have been while testing with this library)

use same logic we do for init (`sync.Once`) in `Server` with our closure of the `c.closer` channel in `Conn`